### PR TITLE
Chore update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "darklake-sdk-on-chain"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anchor-client",
  "anchor-lang",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "dex-math"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d236af12cb43b68cf6a4551c0d460996a25d2ee95f85911f19c382110be4c34"
+checksum = "26e2c445ed9d248b7bab6abcd29046a600e38eb70508cbdaada8cb0b4e25e3eb"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darklake-sdk-on-chain"
-version = "0.4.0"
+version = "0.5.0"
 description = "Darklake DEX SDK - A standalone SDK for interacting directly with Darklake AMM pools"
 edition = "2024"
 authors = ["Darklake Team"]
@@ -24,7 +24,7 @@ bincode = "1.3.3"
 borsh = "1.0.0"
 log = "0.4.20"
 serde_json = "1.0.82"
-dex-math = "0.1.5"
+dex-math = "0.2.0"
 lazy_static = "1.5.0"
 
 # SPL

--- a/src/darklake_amm.rs
+++ b/src/darklake_amm.rs
@@ -82,7 +82,9 @@ pub struct Order {
     pub is_x_to_y: bool,
     pub bump: u8,
 
-    pub padding: [u64; 4],
+    pub lp_fee: u64,
+
+    pub padding: [u64; 3],
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Default)]
@@ -108,7 +110,10 @@ pub struct Pool {
 
     pub bump: u8,
 
-    pub padding: [u64; 4],
+    pub lp_fee_x: u64,
+    pub lp_fee_y: u64,
+
+    pub padding: [u64; 2],
 }
 
 impl Amm for DarklakeAmm {
@@ -244,6 +249,8 @@ impl Amm for DarklakeAmm {
             self.pool.locked_y,
             self.reserve_x_balance,
             self.reserve_y_balance,
+            self.pool.lp_fee_x,
+            self.pool.lp_fee_y,
         )?;
 
         let output_transfer_fee = if is_swap_x_to_y {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds LP fee fields to pool/order and incorporates them into quote calculations, alongside version and dex-math upgrades.
> 
> - **AMM/Swap logic**:
>   - Add `lp_fee` to `Order` and `lp_fee_x`/`lp_fee_y` to `Pool`; adjust paddings.
>   - Pass `pool.lp_fee_x` and `pool.lp_fee_y` into `dex_math::quote`.
> - **Versioning/Dependencies**:
>   - Bump `darklake-sdk-on-chain` to `0.5.0`.
>   - Update `dex-math` to `0.2.0` and refresh `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a5f5ec7b94f021499de5d219376db858a5fa3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->